### PR TITLE
Add docs to README (Fixes #9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,20 @@ The easiest way is to keep `karma-qunit` as a devDependency in your `package.jso
 }
 ```
 
-You can simple do it by:
+You can also use the simple command line installation:
 ```bash
 npm install karma-qunit --save-dev
 ```
 
 ## Configuration
-Following code shows the default configuration...
+Add `qunit` in the `frameworks` array in your `karma.conf.js` file. Then, in the `plugins` array, add `karma-qunit`.
+The following code shows the default configuration:
 ```js
 // karma.conf.js
 module.exports = function(config) {
   config.set({
     frameworks: ['qunit'],
-
+    plugins: ['karma-qunit'],
     files: [
       '*.js'
     ]
@@ -36,7 +37,6 @@ module.exports = function(config) {
 
 ----
 
-For more information on Karma see the [homepage].
-
+For more information on Karma see the [homepage]. If you're using `karma-qunit` to test Ember.js, you might find Karma's [Ember guide](http://karma-runner.github.io/0.12/plus/emberjs.html) helpful.
 
 [homepage]: http://karma-runner.github.com


### PR DESCRIPTION
I wasn't able to get this working without adding `karma-qunit` to the `plugins` array in my `karma.conf.js`. This pull request adds that to the documentation.

It also fixes a grammatical error on line 17, and adds a link to karma's Ember guide.

Fixes #9.
