### PR TITLE
Use QUnit to track total number of tests

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -4,9 +4,22 @@ var createQUnitStartFn = function (tc, runnerPassedIn) {
     var totalNumberOfTest = 0;
     var timer = null;
     var testResult = {};
+    var supportsTestTracking = false;
+
+    if ( runner.begin ) {
+      runner.begin(function( args ) {
+        if ( args && typeof args.totalTests === 'number' ) {
+          tc.info({ total: args.totalTests });
+          supportsTestTracking = true;
+        }
+      });
+    }
 
     runner.done(function () {
-      tc.info({ total: totalNumberOfTest });
+      if ( !supportsTestTracking ) {
+        tc.info({ total: totalNumberOfTest });
+      }
+
       tc.complete({
        coverage: window.__coverage__
       });

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -26,6 +26,41 @@ describe('adapter qunit', function() {
       });
     });
 
+    describe('total number of tests', function() {
+
+      it('should use the tracking in qunit if available', function() {
+        spyOn(tc, 'info').andCallFake(function(result) {
+          expect(result.total).toBe(1);
+        });
+
+        var mockQUnitResult = {
+          totalTests: 1
+        };
+
+        runner.emit('begin', mockQUnitResult);
+        expect(tc.info).toHaveBeenCalled();
+      });
+
+      it('should use our own tracking if none is available', function() {
+        spyOn(tc, 'info').andCallFake(function(result) {
+          expect(result.total).toBe(1);
+        });
+
+        var mockQUnitResult = {
+          name: 'should do something',
+          module: 'desc1',
+          failed: 0
+        };
+
+        runner.emit('testStart', mockQUnitResult);
+        runner.emit('testDone', mockQUnitResult);
+        runner.emit('done');
+
+        expect(tc.info).toHaveBeenCalled();
+      });
+
+    });
+
 
     describe('test end', function() {
 

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -27,6 +27,10 @@ var MockSocket = Emitter;
 var MockRunner = function() {
   Emitter.call(this);
 
+  this.begin = function(fn) {
+    this.on("begin", fn);
+  };
+
   this.done = function(fn) {
     this.on("done", fn);
   };


### PR DESCRIPTION
As of jquery/qunit#553, QUnit will now provide the total number of tests
to be run in their QUnit.begin callback.  This commit will use that
functionality if available, otherwise it falls back to using the current
manual tracking method with QUnit.testStart

fixes #5
