### PR TITLE
feat: Update qunitjs to 1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "karma": ">=0.9",
-    "qunitjs": "~1.14.0"
+    "qunitjs": "~1.15.0"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Allows users of karma-qunit to install qunitjs 1.15.0 alongside.

Perhaps this should be looser so that users aren't constantly blocked on karma-qunit making a release before they can upgrade QUnit.
