### PR TITLE
feat: Update qunitjs to allow newer minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "karma": ">=0.9",
-    "qunitjs": "~1.14.0"
+    "qunitjs": "^1.14.0"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
So that users aren't constantly blocked on karma-qunit making a release before they can upgrade QUnit.
