### PR TITLE
feat: create a qunit-fixture element on test start

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,5 +1,6 @@
 var createQUnitStartFn = function (tc, runnerPassedIn) {
   return function () {
+    var FIXTURE_ID = 'qunit-fixture';
     var runner = runnerPassedIn || window.QUnit;
     var totalNumberOfTest = 0;
     var timer = null;
@@ -29,6 +30,23 @@ var createQUnitStartFn = function (tc, runnerPassedIn) {
       totalNumberOfTest += 1;
       timer = new Date().getTime();
       testResult = { success: true, errors: [] };
+
+      // create a qunit-fixture element to match behaviour of regular qunit
+      // runner. The fixture is only removed at the start of a subsequent test
+      // so it can be inspected after a test run.
+      var fixture = document.getElementById(FIXTURE_ID);
+      if (fixture) {
+        fixture.parentNode.removeChild(fixture);
+      }
+      fixture = document.createElement('div');
+      fixture.id = FIXTURE_ID;
+      // style to match qunit runner's CSS
+      fixture.style.position = 'absolute';
+      fixture.style.left = '-10000px';
+      fixture.style.top = '-10000px';
+      fixture.style.width = '1000px';
+      fixture.style.height = '1000px';
+      document.body.appendChild(fixture);
     });
 
     runner.log(function (details) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -61,6 +61,22 @@ describe('adapter qunit', function() {
 
     });
 
+    describe('test start', function() {
+      it('should create a qunit-fixture element, and remove if exists', function() {
+        runner.emit('testStart', {});
+
+        var fixture = document.getElementById('qunit-fixture');
+        expect(fixture).toBeDefined();
+
+        fixture.className = 'marker';
+        runner.emit('testStart', {});
+
+        fixture = document.getElementById('qunit-fixture');
+        expect(fixture).toBeDefined();
+        expect(fixture.className).not.toBe('marker');
+      });
+
+    });
 
     describe('test end', function() {
 


### PR DESCRIPTION
As per the discussion is #18 - to match the default QUnit HTML runner, and allow for re-use of tests written for this runner with Karma, create a `qunit-fixture` div on test start, removing any existing div with this id if it exists.