### PR TITLE
adapter: enable QUnit configuration passthrough

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+lib/adapter.js

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module.exports = function (config) {
     // client configuration
     client: {
       qunit: {
-        // options
+        testTimeout: 5000
       }
     }
   })

--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ module.exports = function (config) {
 }
 ```
 
+You can also pass options for `QUnit.config` (documented [here](https://api.qunitjs.com/QUnit.config/)) as such:
+
+```js
+/// karma.conf.js
+module.exports = function (config) {
+  config.set({
+    frameworks: ['qunit'],
+    plugins: ['karma-qunit'],
+    files: [
+      '*.js'
+    ],
+
+    // client configuration
+    client: {
+      qunit: {
+        // options
+      }
+    }
+  })
+}
+```
+
 ----
 
 For more information on Karma see the [homepage]. If you're using `karma-qunit` to test Ember.js, you might find Karma's [Ember guide](http://karma-runner.github.io/0.12/plus/emberjs.html) helpful.

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -2,7 +2,7 @@ function createQUnitConfig (karma, defaultConfig) { // eslint-disable-line no-un
   var config = defaultConfig || {}
 
   if (!karma.config || !karma.config.qunit) {
-    return
+    return {}
   }
 
   for (var key in karma.config.qunit) {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,3 +1,17 @@
+function createQUnitConfig (karma, defaultConfig) { // eslint-disable-line no-unused-vars
+  var config = defaultConfig || {}
+
+  if (!karma.config || !karma.config.qunit) {
+    return
+  }
+
+  for (var key in karma.config.qunit) {
+    config[key] = karma.config.qunit[key]
+  }
+
+  return config
+}
+
 function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unused-vars
   return function () {
     var FIXTURE_ID = 'qunit-fixture'

--- a/src/adapter.wrapper
+++ b/src/adapter.wrapper
@@ -2,7 +2,13 @@
 
 %CONTENT%
 
-window.QUnit.config.autostart = false;
+var config = createQUnitConfig(window.__karma__, {
+  autostart: false
+});
+
+for (var key in config) {
+  window.QUnit.config[key] = config[key];
+}
 
 if (window.removeEventListener) {
   window.removeEventListener('load', window.QUnit.load, false);

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -1,10 +1,46 @@
-/* global MockSocket, MockRunner, createQUnitStartFn, reporter:true */
+/* global MockSocket, MockRunner, createQUnitStartFn, createQUnitConfig reporter:true */
 
 // Tests for adapter/qunit.src.js
 // These tests are executed in browser.
 
 describe('adapter qunit', function () {
   var Karma = window.__karma__.constructor
+
+  describe('config', function () {
+    var config
+    var tc
+
+    beforeEach(function () {
+      tc = new Karma(new MockSocket(), null, null, null, {search: ''})
+    })
+
+    it('should return the default configuration passed', function () {
+      tc.config.qunit = {}
+      config = createQUnitConfig(tc, {autostart: false})
+      expect(config.autostart).toBe(false)
+    })
+
+    it('should return the configuration defined on the runner', function () {
+      tc.config.qunit = {
+        autostart: false
+      }
+      config = createQUnitConfig(tc)
+      expect(config.autostart).toBe(false)
+    })
+
+    it('should prefer configuration on the runner', function () {
+      tc.config.qunit = {
+        autostart: true
+      }
+      config = createQUnitConfig(tc, {autostart: false})
+      expect(config.autostart).toBe(true)
+    })
+
+    it('should return an empty object for no client config', function () {
+      config = createQUnitConfig(tc)
+      expect(config).toEqual({})
+    })
+  })
 
   describe('reporter', function () {
     var runner


### PR DESCRIPTION
### What's in here

This PR adds the ability to pass through [QUnit `config` values](https://api.qunitjs.com/QUnit.config/) to the `window.QUnit` instance. It preserves the `autostart` behavior and allows clients to override by writing into `client.qunit` as the [`karma-mocha` allows](https://github.com/karma-runner/karma-mocha).

The original intent for this PR is to enable clients to do easy module filtering, @marcins took a stab at this in https://github.com/karma-runner/karma-qunit/pull/29, but unfortunately it appears that `filter` is an undocumented configuration value for `window.QUnit.config` and I would rather insist on using the public API here for stability. As such, I do not want to be pinned to specific adapter keys at the top level that tie themselves to a key on `window.QUnit.config` (in the case of #29 this is `filter`), but I want to enable a passthrough of all values onto the `window.QUnit` instance so that future upgrades to QUnit behind the scenes are transparent to clients.

An example configuration would look like:

```js
module.exports = function(config) {
  config.set({
    ...
    client: {
      qunit: {
        moduleFilter: '<pattern>',
        ...
      }
      ...
    }
  });
};
```

Please let me know if this is amenable and any changes that need to be made for this to be merged. Thanks!