### PR TITLE
Wrap the qunit expected and actual entries in calls to the qunit form…

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -74,7 +74,7 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
         }
 
         if (typeof details.expected !== 'undefined') {
-          msg += 'Expected: ' + details.expected + '\n' + 'Actual: ' + details.actual + '\n'
+          msg += 'Expected: ' + runner.dump.parse(details.expected) + '\n' + 'Actual: ' + runner.dump.parse(details.actual) + '\n'
         }
 
         if (details.source) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -136,7 +136,7 @@ describe('adapter qunit', function () {
       it('should report failed result', function () {
         spyOn(tc, 'result').and.callFake(function (result) {
           expect(result.success).toBe(false)
-          expect(result.log).toEqual(['Big trouble.\n'])
+          expect(result.log).toEqual(['Big trouble.\nExpected: ' + JSON.stringify(expected) + '\nActual: undefined' + '\n' ])
         })
 
         var mockQUnitResult = {
@@ -145,9 +145,12 @@ describe('adapter qunit', function () {
           name: 'should do something'
         }
 
+        var expected = {foo: 'bar', baz: [1, 2, 3]}
+
         var mockQUnitLog = {
           result: false,
-          message: 'Big trouble.'
+          message: 'Big trouble.',
+          expected: expected
         }
 
         runner.emit('testStart', mockQUnitResult)

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -54,4 +54,11 @@ var MockRunner = function () { // eslint-disable-line no-unused-vars
   this.start = function () {
     // NOOP
   }
+
+  this.dump = {
+    parse: function (input) {
+      return JSON.stringify(input)
+    }
+  }
+
 }


### PR DESCRIPTION
…atter so you get useful ouput on failed assertions instead of just [object Object]

This addresses #24 