### PR TITLE
allow karma v2 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "qunitjs": "^2.0.0"
   },
   "peerDependencies": {
-    "qunitjs": "^1.14.0"
+    "qunitjs": "^1.14.0 || ^2.0.0"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
The 2.0 release of QUnit lead to the current peer dependency requirement of `karma-qunit` not being fulfilled anymore:

```
npm ERR! peerinvalid The package qunitjs@2.0.0 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer karma-qunit@1.1.0 wants qunitjs@^1.14.0
```

This PR allows all versions of QUnit and lets users freely chose. (Just like e.g. [karma-mocha](https://github.com/karma-runner/karma-mocha/blob/master/package.json#L48))