### PR TITLE
fix(adapter): only create fixture at begin and only if none exists prior

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -34,6 +34,24 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
           tc.info({ total: args.totalTests })
           supportsTestTracking = true
         }
+
+        if (typeof document !== 'undefined' && document.getElementById && document.createElement && document.body) {
+          // Create a qunit-fixture element to match behaviour of regular qunit runner.
+          // The fixture is only created once when the runner begins.
+          // Resetting is handled by qunit
+          var fixture = document.getElementById(FIXTURE_ID)
+          if (!fixture) {
+            fixture = document.createElement('div')
+            fixture.id = FIXTURE_ID
+            // style to match qunit runner's CSS
+            fixture.style.position = 'absolute'
+            fixture.style.left = '-10000px'
+            fixture.style.top = '-10000px'
+            fixture.style.width = '1000px'
+            fixture.style.height = '1000px'
+            document.body.appendChild(fixture)
+          }
+        }
       })
     }
 
@@ -51,25 +69,6 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
       totalNumberOfTest += 1
       timer = new Date().getTime()
       testResult = { success: true, errors: [] }
-
-      if (typeof document !== 'undefined' && document.getElementById && document.createElement && document.body) {
-        // create a qunit-fixture element to match behaviour of regular qunit
-        // runner. The fixture is only removed at the start of a subsequent test
-        // so it can be inspected after a test run.
-        var fixture = document.getElementById(FIXTURE_ID)
-        if (fixture) {
-          fixture.parentNode.removeChild(fixture)
-        }
-        fixture = document.createElement('div')
-        fixture.id = FIXTURE_ID
-        // style to match qunit runner's CSS
-        fixture.style.position = 'absolute'
-        fixture.style.left = '-10000px'
-        fixture.style.top = '-10000px'
-        fixture.style.width = '1000px'
-        fixture.style.height = '1000px'
-        document.body.appendChild(fixture)
-      }
     })
 
     runner.log(function (details) {

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -105,18 +105,35 @@ describe('adapter qunit', function () {
     })
 
     describe('test start', function () {
-      it('should create a qunit-fixture element, and remove if exists', function () {
-        runner.emit('testStart', {})
-
+      it('should create a qunit-fixture element if none exists', function () {
         var fixture = document.getElementById('qunit-fixture')
-        expect(fixture).toBeDefined()
+        if (fixture) {
+          fixture.parentNode.removeChild(fixture)
+          fixture = document.getElementById('qunit-fixture')
+        }
+        expect(fixture).toBe(null)
 
-        fixture.className = 'marker'
+        runner.emit('begin', {})
         runner.emit('testStart', {})
 
         fixture = document.getElementById('qunit-fixture')
         expect(fixture).toBeDefined()
-        expect(fixture.className).not.toBe('marker')
+      })
+
+      it('should preserve any existing qunit-fixture element', function () {
+        var fixture = document.getElementById('qunit-fixture')
+        if (!fixture) {
+          fixture = document.createElement('div')
+          fixture.id = 'qunit-fixture'
+          document.body.appendChild(fixture)
+        }
+        fixture.className = 'marker'
+
+        runner.emit('begin', {})
+        runner.emit('testStart', {})
+
+        fixture = document.getElementById('qunit-fixture')
+        expect(fixture.className).toBe('marker')
       })
     })
 


### PR DESCRIPTION
QUnit already deals with re-creating this every test run.

Re-creating it every test override QUnit's internal behaviour and (among other subtle differences) means `QUnit.config.fixture` content is missing at run-time.

Fixes #92