### PR TITLE
chore: Fix Travis build (update Node versions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "iojs"
-  - "0.12"
-  - "0.10"
+  - "4"
+  - "6"
+  - "7"
 
 # Make sure we have new NPM.
 before_install:
@@ -10,6 +10,3 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - npm install -g npm
   - npm config set loglevel warn
-
-before_script:
-  - npm install -g grunt-cli


### PR DESCRIPTION
The build is broken (if you try to re-trigger from clean master) because `.travis.yml` updates npm to the latest version (`Make sure we have new NPM.`) but the latest npm does not support Node 0.10 and Node 0.12, as indicated by the fatal error for npm's internal use of `Object.assign()` which was not implemented by V8 and Node at the time.