### PR TITLE
docs: update outdated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ module.exports = function (config) {
 }
 ```
 
-You can also pass options for `QUnit.config` (documented [here](https://api.qunitjs.com/QUnit.config/)) as such:
+You can also pass options for `QUnit.config` (documented [here](https://api.qunitjs.com/config/QUnit.config)) as such:
 
 ```js
 /// karma.conf.js
@@ -62,6 +62,6 @@ Note: `showUI: true` needs the `clearContext: false` option to display correctly
 
 ----
 
-For more information on Karma see the [homepage]. If you're using `karma-qunit` to test Ember.js, you might find Karma's [Ember guide](http://karma-runner.github.io/0.12/plus/emberjs.html) helpful.
+For more information on Karma see the [homepage]. If you're using `karma-qunit` to test Ember.js, you might find Karma's [Ember guide](http://karma-runner.github.io/1.0/plus/emberjs.html) helpful.
 
 [homepage]: http://karma-runner.github.com


### PR DESCRIPTION
Fixed broken link to QUnit.config documentation, and updated link to Karma's Ember guide.