### PR TITLE
fix(adapter): honor config "autostart"

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -111,6 +111,9 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
     })
 
     runner.load()
-    runner.start()
+    // honor autostart config, useful for tests loaded asynchronously
+    if (config.autostart !== false) {
+      runner.start()
+    }
   }
 }

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -45,6 +45,37 @@ describe('adapter qunit', function () {
     })
   })
 
+  describe('runner', function () {
+    var tc
+    var runner
+
+    beforeEach(function () {
+      tc = new Karma(new MockSocket(), null, null, null, {search: ''})
+      runner = new MockRunner()
+    })
+
+    describe('start', function () {
+      it('should auto start on __karma__.start by default', function () {
+        spyOn(runner, 'start')
+
+        createQUnitStartFn(tc, runner)()
+        expect(runner.start).toHaveBeenCalled()
+      })
+
+      it('should honor runner config "autostart"', function () {
+        tc.config = {}
+        tc.config.qunit = {
+          autostart: false
+        }
+
+        spyOn(runner, 'start')
+
+        createQUnitStartFn(tc, runner)()
+        expect(runner.start).not.toHaveBeenCalled()
+      })
+    })
+  })
+
   describe('reporter', function () {
     var runner
     var tc


### PR DESCRIPTION
`QUnit.config.autostart` defaults to `true` and is set to `false` in the adapter, though it's still acting as `autostart: true` to the end user as the adapter executes `runner.start()` on karma load. I think that's exptected.

But when `autostart: false` is passed in explicitly via `tc.config.qunit`, QUnit still auto starts in the adapter code.

So I added a check before running `runner.start()` and added some tests for this.