### PR TITLE
Add timeout before starting qunit

### DIFF
--- a/examples/simple/.eslintrc
+++ b/examples/simple/.eslintrc
@@ -1,5 +1,6 @@
 {
   "env": {
-    "qunit": true
+    "qunit": true,
+    "jquery": true
   }
 }

--- a/examples/simple/karma.conf.js
+++ b/examples/simple/karma.conf.js
@@ -3,6 +3,7 @@ module.exports = function (config) {
     frameworks: ['qunit'],
 
     files: [
+      'https://code.jquery.com/jquery-3.3.1.min.js',
       '*'
     ],
 

--- a/examples/simple/test-with-lib.js
+++ b/examples/simple/test-with-lib.js
@@ -1,0 +1,6 @@
+$(function () {
+  QUnit.test('it works', function (assert) {
+    assert.expect(1)
+    assert.strictEqual(1 + 1, 2)
+  })
+})

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -23,6 +23,7 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
     var testResult = {}
     var supportsTestTracking = false
     var config = (tc.config && tc.config.qunit) || {}
+    var qunitOldTimeout = 13
 
     if (config.showUI) {
       var ui = document.createElement('div')
@@ -115,7 +116,9 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
 
     // honor autostart config, useful for tests loaded asynchronously
     if (config.autostart !== false) {
-      runner.start()
+      setTimeout(function () {
+        runner.start()
+      }, qunitOldTimeout)
     }
   }
 }

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -55,14 +55,17 @@ describe('adapter qunit', function () {
     })
 
     describe('start', function () {
-      it('should auto start on __karma__.start by default', function () {
+      it('should auto start on __karma__.start by default', function (done) {
         spyOn(runner, 'start')
 
         createQUnitStartFn(tc, runner)()
-        expect(runner.start).toHaveBeenCalled()
+        setTimeout(function () {
+          expect(runner.start).toHaveBeenCalled()
+          done()
+        }, 13)
       })
 
-      it('should honor runner config "autostart"', function () {
+      it('should honor runner config "autostart"', function (done) {
         tc.config = {}
         tc.config.qunit = {
           autostart: false
@@ -71,7 +74,10 @@ describe('adapter qunit', function () {
         spyOn(runner, 'start')
 
         createQUnitStartFn(tc, runner)()
-        expect(runner.start).not.toHaveBeenCalled()
+        setTimeout(function () {
+          expect(runner.start).not.toHaveBeenCalled()
+          done()
+        }, 13)
       })
     })
   })


### PR DESCRIPTION
In this PR QUnit removed their timeout : https://github.com/qunitjs/qunit/pull/1246 so we try to run unit tests before they are loaded, that leads to error like `No tests were run.`

Fixes: #103 

/CC @XhmikosR @dignifiedquire