### PR TITLE
use qunit css instead of inline styles

### DIFF
--- a/examples/simple/test-with-fixture.js
+++ b/examples/simple/test-with-fixture.js
@@ -1,0 +1,16 @@
+QUnit.test('set innerHTML', function (assert) {
+  document.querySelector('#qunit-fixture').innerHTML = 'foo'
+  assert.ok(true)
+})
+
+QUnit.test('verify that innerHTML is reset', function (assert) {
+  assert.equal(document.querySelector('#qunit-fixture').innerHTML, '')
+})
+
+QUnit.test('verify the styles', function (assert) {
+  var rect = document.querySelector('#qunit-fixture').getBoundingClientRect()
+  assert.strictEqual(rect.bottom, -9000)
+  assert.strictEqual(rect.left, -10000)
+  assert.strictEqual(rect.right, -9000)
+  assert.strictEqual(rect.top, -10000)
+})

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,15 +9,13 @@ function createPattern (pattern) {
   }
 }
 
-function initQUnit (files, qunit) {
+function initQUnit (files) {
   files.unshift(createPattern(path.join(__dirname, 'adapter.js')))
   files.unshift(createPattern(require.resolve('qunit')))
-  if (qunit && qunit.showUI) {
-    files.unshift(createPattern(require.resolve('qunit/qunit/qunit.css')))
-  }
+  files.unshift(createPattern(require.resolve('qunit/qunit/qunit.css')))
 }
 
-initQUnit.$inject = ['config.files', 'config.client.qunit']
+initQUnit.$inject = ['config.files']
 
 module.exports = {
   'framework:qunit': ['factory', initQUnit]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "grunt eslint",
-    "test": "grunt && mocha test/lib",
+    "test": "grunt",
     "test:lib": "mocha test/lib"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lint": "grunt eslint",
-    "test": "grunt",
+    "test": "grunt && mocha test/lib",
     "test:lib": "mocha test/lib"
   },
   "repository": {

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -46,12 +46,6 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
           if (!fixture) {
             fixture = document.createElement('div')
             fixture.id = FIXTURE_ID
-            // style to match qunit runner's CSS
-            fixture.style.position = 'absolute'
-            fixture.style.left = '-10000px'
-            fixture.style.top = '-10000px'
-            fixture.style.width = '1000px'
-            fixture.style.height = '1000px'
             document.body.appendChild(fixture)
             if (typeof runner.config.fixture === 'undefined') {
               runner.config.fixture = ''

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -8,23 +8,21 @@ describe('framework:qunit', function () {
     files = []
   })
 
-  it('should add adapter.js', function () {
+  it('should add qunit.css', function () {
     initQunit(files)
 
-    expect(files[1].pattern).to.contain('adapter.js')
+    expect(files[0].pattern).to.contain('qunit.css')
   })
 
   it('should add qunit.js', function () {
     initQunit(files)
 
-    expect(files[0].pattern).to.contain('qunit.js')
+    expect(files[1].pattern).to.contain('qunit.js')
   })
 
-  it('should add qunit.css if we define showUI in config', function () {
-    var qunitConfig = {showUI: true}
+  it('should add adapter.js', function () {
+    initQunit(files)
 
-    initQunit(files, qunitConfig)
-
-    expect(files[0].pattern).to.contain('qunit.css')
+    expect(files[2].pattern).to.contain('adapter.js')
   })
 })

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -148,16 +148,15 @@ describe('adapter qunit', function () {
       })
     })
 
-    describe('test start', function () {
+    describe('test begin', function () {
       it('should create a qunit-fixture element if none exists', function () {
         var fixture = document.getElementById('qunit-fixture')
         expect(fixture).toBe(null)
 
         runner.emit('begin', {})
-        runner.emit('testStart', {})
 
         fixture = document.getElementById('qunit-fixture')
-        expect(fixture).toBeDefined()
+        expect(fixture).not.toBe(null)
         expect(runner.config.fixture).toBe('')
       })
 
@@ -168,10 +167,9 @@ describe('adapter qunit', function () {
         document.body.appendChild(fixture)
 
         runner.emit('begin', {})
-        runner.emit('testStart', {})
 
         fixture = document.getElementById('qunit-fixture')
-        expect(fixture).toBeDefined()
+        expect(fixture).not.toBe(null)
         expect(fixture.className).toBe('marker')
         expect(runner.config.fixture).toBeUndefined()
       })
@@ -179,10 +177,9 @@ describe('adapter qunit', function () {
       it('should honor runner config "fixture"', function () {
         runner.config.fixture = '<div>html fixture</div>'
         runner.emit('begin', {})
-        runner.emit('testStart', {})
 
         var fixture = document.getElementById('qunit-fixture')
-        expect(fixture).toBeDefined()
+        expect(fixture).not.toBe(null)
         expect(runner.config.fixture).toBe('<div>html fixture</div>')
       })
     })


### PR DESCRIPTION
As discussed in #109 this is what it would look like if we got rid of inline styles for `qunit-fixture` and used QUnit CSS instead.