### PR TITLE
chore(ci): Sync logic between travis/npm/grunt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,5 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 
 script:
-  - yarn lint
   - yarn test
   - npm run test:lib

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,5 @@
 module.exports = function (grunt) {
   grunt.initConfig({
-    pkgFile: 'package.json',
     'npm-contributors': {
       options: {
         commitMessage: 'chore: update contributors'
@@ -44,8 +43,8 @@ module.exports = function (grunt) {
   require('load-grunt-tasks')(grunt)
   grunt.loadTasks('tasks')
 
-  grunt.registerTask('test', ['build', 'karma'])
-  grunt.registerTask('default', ['eslint', 'test'])
+  grunt.registerTask('test', ['eslint', 'build', 'karma'])
+  grunt.registerTask('default', ['test'])
 
   grunt.registerTask('release', 'Bump the version and publish to NPM.', function (type) {
     grunt.task.run([


### PR DESCRIPTION
* Remove superfluous 'yarn lint' script in addition to 'yarn test',
  which already did the same (yarn test > scripts.test >
  grunt default > eslint + grunt test).

* Move the running of eslint as part of "test" further down the
  stack (into 'grunt test' instead of joining only as part of
  grunt [default]).

* Remove unused `pgkFile` property.

* Rename `gruntfile.js` to `Gruntfile.js`, matching the current
  practice and expectation of users and contributors.