### PR TITLE
chore: Simplify karma browsers config

### DIFF
--- a/examples/simple/karma.conf.js
+++ b/examples/simple/karma.conf.js
@@ -17,13 +17,13 @@ module.exports = function (config) {
 
     autoWatch: false,
 
-    browsers: process.env.CI ? ['ChromeHeadless'] : ['Chrome'],
+    browsers: ['FirefoxHeadless'],
 
     singleRun: false,
 
     plugins: [
       require('../../lib/index.js'),
-      'karma-chrome-launcher'
+      'karma-firefox-launcher'
     ]
   })
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,3 @@
-var FIREFOX = process.env.CI ? ['FirefoxHeadless'] : ['Firefox']
-var CHROME = process.env.CI ? ['ChromeHeadless'] : ['Chrome']
-
 module.exports = function (config) {
   config.set({
     frameworks: ['jasmine'],
@@ -10,14 +7,7 @@ module.exports = function (config) {
       'test/src/*.js'
     ],
 
-    browsers: process.env.CI ? FIREFOX : CHROME,
-
-    customLaunchers: {
-      FirefoxHeadless: {
-        base: 'Firefox',
-        flags: ['-headless']
-      }
-    },
+    browsers: ['FirefoxHeadless'],
 
     autoWatch: true
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "karma-qunit",
       "version": "4.1.2",
       "license": "MIT",
       "devDependencies": {
@@ -20,7 +19,6 @@
         "grunt-bump": "^0.8.0",
         "grunt-npm": "0.0.2",
         "karma": "^6.3.9",
-        "karma-chrome-launcher": "^3.1.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^4.0.1",
         "mocha": "^9.1.3",
@@ -589,6 +587,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2657,6 +2656,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -2696,27 +2698,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/karma-chrome-launcher": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
-      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
-      "dev": true,
-      "dependencies": {
-        "which": "^1.2.1"
-      }
-    },
-    "node_modules/karma-chrome-launcher/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/karma-firefox-launcher": {
@@ -6516,26 +6497,6 @@
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
           "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
           "dev": true
-        }
-      }
-    },
-    "karma-chrome-launcher": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz",
-      "integrity": "sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==",
-      "dev": true,
-      "requires": {
-        "which": "^1.2.1"
-      },
-      "dependencies": {
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "grunt-bump": "^0.8.0",
     "grunt-npm": "0.0.2",
     "karma": "^6.3.9",
-    "karma-chrome-launcher": "^3.1.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^4.0.1",
     "mocha": "^9.1.3",


### PR DESCRIPTION
The "Firefox" and "HeadlessChrome" arrays were unreachable as `env.CI` was not set in one place and then unset in the other.

If there is reason to cover Firefox and Chrome for this project specifically we can always test both in parallel, but I'm not aware of such reason.

This commit follows CI's lead and makes local development use the same browser (Firefox) which has the benefit of working headlessly out-of-the-box both on bare metal desktops. and in e.g. a Docker container developer environment without needing local, and in CI VMS - without needing custom overrides or configs (e.g. `--no-sandbox`, root, or Xvfb)

Also use headless by default everywhere so that `npm test` works out of the box for contributors if they use a secure development container where there's no graphical display or Xvfb running, and so that it is more likely to match
CI behaviour. One can still override as before, by passing `--browsers` to the karma command (as such, I've kept the chrome-launcher depencency so that people preferring to debug there, can still easily do so).