### PR TITLE
Fix CI due to GH Actions regression (missing Firefox)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
 jobs:
   run:
     name: Node ${{ matrix.node }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
GitHub has rolled out Ubuntu 22 as the new default but this is still missing Firefox, causing the following failure for all jobs:

> Starting browser FirefoxHeadless
> ERROR [launcher]: Cannot start FirefoxHeadless
> Can not find the binary `firefox`

Ref https://github.com/actions/runner-images/issues/5490