### PR TITLE
Remove use of deprecated `QUnit.load()`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "karma-qunit",
       "version": "4.1.2",
       "license": "MIT",
       "devDependencies": {
@@ -26,7 +27,7 @@
       },
       "peerDependencies": {
         "karma": "^4.0.0 || ^5.0.0 || ^6.0.0",
-        "qunit": "^2.0.0"
+        "qunit": "^2.1.1"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "karma": "^4.0.0 || ^5.0.0 || ^6.0.0",
-    "qunit": "^2.0.0"
+    "qunit": "^2.1.1"
   },
   "license": "MIT",
   "contributors": [

--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,14 +1,14 @@
 'use strict'
 
-function createQUnitConfig (karma, defaultConfig) { // eslint-disable-line no-unused-vars
-  var config = defaultConfig || {}
-
-  if (!karma.config || !karma.config.qunit) {
-    return config
+function createQUnitConfig (karma) { // eslint-disable-line no-unused-vars
+  var config = {
+    autostart: false
   }
 
-  for (var key in karma.config.qunit) {
-    config[key] = karma.config.qunit[key]
+  if (karma.config && karma.config.qunit) {
+    for (var key in karma.config.qunit) {
+      config[key] = karma.config.qunit[key]
+    }
   }
 
   return config
@@ -111,9 +111,17 @@ function createQUnitStartFn (tc, runnerPassedIn) { // eslint-disable-line no-unu
       tc.result(result)
     })
 
-    runner.load()
-
-    // honor autostart config, useful for tests loaded asynchronously
+    // karma-qunit uses `QUnit.config.autostart = false` internally
+    // so window.__karma__.start (points to here) controls QUnit.start
+    // and thus naturally waits for any file-loading karma plugins
+    // (especially async like AMD/RequireJS).
+    //
+    // ensure the the option to turn off QUnit autostart is also
+    // available to end-users, by letting them set `qunit.autostart: false`
+    // in karma.config.js. The end-user may then call QUnit.start() when
+    // they are ready.
+    //
+    // https://github.com/karma-runner/karma-qunit/issues/27
     if (config.autostart !== false) {
       setTimeout(function () {
         runner.start()

--- a/src/adapter.wrapper
+++ b/src/adapter.wrapper
@@ -2,18 +2,10 @@
 
 %CONTENT%
 
-var config = createQUnitConfig(window.__karma__, {
-  autostart: false
-});
+var config = createQUnitConfig(window.__karma__);
 
 for (var key in config) {
   window.QUnit.config[key] = config[key];
-}
-
-if (window.removeEventListener) {
-  window.removeEventListener('load', window.QUnit.load, false);
-} else if (window.detachEvent) {
-  window.detachEvent('onload', window.QUnit.load);
 }
 
 window.__karma__.start = createQUnitStartFn(window.__karma__);

--- a/test/src/adapter.spec.js
+++ b/test/src/adapter.spec.js
@@ -24,7 +24,7 @@ describe('adapter qunit', function () {
     it('should return the default configuration passed', function () {
       tc.config = {}
       tc.config.qunit = {}
-      config = createQUnitConfig(tc, { autostart: false })
+      config = createQUnitConfig(tc)
       expect(config.autostart).toBe(false)
     })
 
@@ -42,12 +42,12 @@ describe('adapter qunit', function () {
       tc.config.qunit = {
         autostart: true
       }
-      config = createQUnitConfig(tc, { autostart: false })
+      config = createQUnitConfig(tc)
       expect(config.autostart).toBe(true)
     })
 
     it('should return the default config for no client config', function () {
-      config = createQUnitConfig(tc, { autostart: false })
+      config = createQUnitConfig(tc)
       expect(config).toEqual({ autostart: false })
     })
   })

--- a/test/src/mocks.js
+++ b/test/src/mocks.js
@@ -49,10 +49,6 @@ var MockRunner = function () { // eslint-disable-line no-unused-vars
     this.on('log', fn)
   }
 
-  this.load = function () {
-    // NOOP
-  }
-
   this.start = function () {
     // NOOP
   }


### PR DESCRIPTION
QUnit 2.21.0 will be emitting a deprecation warning from QUnit.load.

Calling this method has not been needed for several years, since QUnit 2.1.1, released in 2017.
https://github.com/qunitjs/qunit/releases/tag/2.1.1

Also:
* document how this works.
* remove unused `defaultConfig` parameter. It is only ever used one way in src/, and tests didn't cover other input anyway. It now improves test coverage by covering the actual value instead of relying on tests passing the same as the real code.